### PR TITLE
7 __MODULE__ aliases are not being sorted in the correct order

### DIFF
--- a/lib/eunomo/formatter/alphabetical_alias_sorter.ex
+++ b/lib/eunomo/formatter/alphabetical_alias_sorter.ex
@@ -15,6 +15,8 @@ defmodule Eunomo.Formatter.AlphabeticalAliasSorter do
       iex> code_snippet = \"\"\"
       ...> alias Eunomo.Z.{L, I}
       ...> alias Eunomo.Z
+      ...> alias __MODULE__.B
+      ...> alias __MODULE__.A
       ...> alias Eunomo.{
       ...>   L,
       ...>   B,
@@ -27,6 +29,8 @@ defmodule Eunomo.Formatter.AlphabeticalAliasSorter do
       ...> \"\"\"
       ...> Eunomo.format_string(code_snippet, [Eunomo.Formatter.AlphabeticalAliasSorter])
       \"\"\"
+      alias __MODULE__.A
+      alias __MODULE__.B
       alias Eunomo.C
       alias Eunomo.Z
       alias Eunomo.Z.{L, I}

--- a/lib/eunomo/formatter/alphabetical_expression_sorter.ex
+++ b/lib/eunomo/formatter/alphabetical_expression_sorter.ex
@@ -77,7 +77,7 @@ defmodule Eunomo.Formatter.AlphabeticalExpressionSorter do
   defp ast_block_to_modifications({:__block__, _, args}, split_expression) do
     args
     |> split_into_expression_blocks(split_expression)
-    |> Enum.map(&Enum.sort_by(&1, fn t -> t |> Macro.to_string() |> String.upcase() end))
+    |> Enum.map(&Enum.sort_by(&1, fn t -> t |> Macro.to_string() |> String.downcase() end))
     |> accumulate_modifications(split_expression)
   end
 


### PR DESCRIPTION
Fixes all sorting to be consistent with Credo sorting. See https://github.com/rrrene/credo/blob/master/lib/credo/check/readability/alias_order.ex

Credo checks sorting by `String.downcase` but we were sorting by `String.upcase`.