### PR TITLE
Introduce Mix.Tasks.Format compatible Adapter

### DIFF
--- a/lib/mix/tasks/format/eunomo.ex
+++ b/lib/mix/tasks/format/eunomo.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.Format.Eunomo do
+  @moduledoc """
+  Eunomo Adapter to be compatible with the Mix Format interface.
+  
+  ## Usage
+  
+  ```elixir
+  # .formatter.exs
+  [
+    # Add Eunomo to your formatter plugins
+    plugins: [Mix.Tasks.Format.Eunomo]
+  ]
+  ```
+  """
+
+  @behaviour Mix.Tasks.Format
+
+  def features(_opts) do
+    [extensions: [".ex", ".exs"]]
+  end
+
+  def format(contents, _opts) do
+    contents
+    |> Eunomo.format_string([
+      Eunomo.Formatter.AlphabeticalAliasSorter,
+      Eunomo.Formatter.AlphabeticalImportSorter,
+      Eunomo.Formatter.AlphabeticalRequireSorter
+    ])
+  end
+end


### PR DESCRIPTION
As my Team encountered issues with Eunomo in an Umbrella App I began to analyze the Issue. During this analysis I found the `Mix.Tasks.Format` interface which allows to extend the `mix format` and `mix format --check-formatted` commands.

The proposed change introduces an Adapter for Eunomo to integrate into the default `mix format` commands. Doing it like this leaves the whole Umbrella specific handling with `mix format` while solving our need for eunomo to work in an Umbrella App, without introducing the complexity of handling Umbrellas into Eunomo.

We love Eunomo for it helps us every day keeping up against the always growing list of alias, require and import statemetns to be sorted so credo doesn't get mad at us ;)